### PR TITLE
S3 uri

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: noctua
 Type: Package
 Title: Connect to 'AWS Athena' using R 'AWS SDK' 'paws' ('DBI' Interface)
-Version: 1.1.0.9000
+Version: 1.1.0.9001
 Authors@R: person("Dyfan", "Jones", email="dyfan.r.jones@gmail.com", 
                   role= c("aut", "cre"))
 Description: Designed to be compatible with the 'R' package 'DBI' (Database Interface)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# noctua 1.1.0.9001
+### Minor Change
+* `s3.location` parameter is `dbWriteTable` can now be made nullable
+
+### Backend Change
+* helper function `upload_data` has been rebuilt and removed the old "horrible" if statement with `paste` now the function relies on `sprintf` to construct the s3 location path. This method now is alot clearer in how the s3 location is created plus it enables a `dbWriteTable` to be simplified. `dbWriteTable` can now upload data to the default s3_staging directory created in `dbConnect` this simplifies `dbWriteTable` to :
+```
+library(DBI)
+
+con <- dbConnect(noctua:athena())
+
+dbWrite(con, "iris", iris)
+```
+### Bug Fix
+* Info message wasn't being return when colnames needed changing for Athena DDL
+
+### Unit Tests
+* `data transfer` test now tests compress, and default s3.location when transfering data
+
 # noctua 1.1.0.9000
 ### New Feature
 * GZIP compression is now supported for "csv" and "tsv" file format in `dbWriteTable`

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,16 +1,11 @@
 ## Release Summary
-This is a quick release due to the changes in the dependent package `paws`. `paws` has enabled connection credentials to be passed through to `paws` objects, causing an error in several wrapping functions for example: `dbSendQuery`. In this release the bugs are addressed plus it contains new feature updates: 
-
-* Setting `data.table` as the default file parser
-* Handling of 'AWS Athena' `bigint` classes
+This is a feature updated, focusing on methods to compress flat files before submitting them to `Amazon Web Service S3`. 
 
 In this version I have:
+* created a new parameter in `dbWriteTable` called `compress` that enables compression method `gzip` to be utilised when sending data to AWS S3.
 
-* **BUG FIX:** all wrapper functions with error: `Error in call[[2]] : object of type 'closure' is not subsettable` have been fixed by the removal of `do.call`
-* Enabled connection parameters to pass through the new `config = list()` in `paws` objects
-* Correctly pass Amazon Web Service ('AWS') Athena `bigint` to R `integer64` class.
-* data.table has been made a dependency as `fread` and `fwrite` have been made the default file reader and writer to transfer data to and from 'AWS Athena'
-
+**Bug Fix**
+* Fixed minor bug of s3_uri being incorrectly built
 ## Examples Note:
 * All R examples with `\dontrun` & `\donttest` have been given a note warning users that `AWS credentials` are required to run
 * All R examples with `\dontrun` have a dummy `AWS S3 Bucket uri` example and won't run until user replace the `AWS S3 bucket uri`.
@@ -23,18 +18,10 @@ In this version I have:
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
 ## R devtools::check_rhub() results
-0 errors ✔ | 0 warnings ✔ | 1 note ✖
 
-checking CRAN incoming feasibility ... NOTE
-  Maintainer: 'Dyfan Jones <dyfan.r.jones@gmail.com>'
-  
-  Days since last update: 3
-  
-### Author notes:
-Due to the update in the dependency `paws` a bug has developed in several wrapper functions. This release addresses these bugs.
 
 ## unit tests (using testthat) results
-* OK:       36
+* OK:       37
 * Failed:   0
 * Warnings: 0
 * Skipped:  0

--- a/man/AthenaWriteTables.Rd
+++ b/man/AthenaWriteTables.Rd
@@ -54,7 +54,8 @@ For backward compatibility, \code{NULL} is equivalent to \code{FALSE}.}
 
 \item{partition}{Partition Athena table (needs to be a named list or vector) for example: \code{c(var1 = "2019-20-13")}}
 
-\item{s3.location}{s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/")}
+\item{s3.location}{s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/").
+By default s3.location is set s3 staging directory from \code{\linkS4class{AthenaConnection}} object.}
 
 \item{file.type}{What file type to store data.frame on s3, noctua currently supports ["csv", "tsv", "parquet"].
 \strong{Note:} "parquet" format is supported by the \code{arrow} package and it will need to be installed to utilise the "parquet" format.}
@@ -99,6 +100,18 @@ dbListTables(con)
 
 # Checking if uploaded table exists in Athena
 dbExistsTable(con, "mtcars")
+
+# using default s3.location
+dbWriteTable(con, "iris", iris)
+
+# Read entire table from Athena
+dbReadTable(con, "iris")
+
+# List all tables in Athena after uploading new table to Athena
+dbListTables(con)
+
+# Checking if uploaded table exists in Athena
+dbExistsTable(con, "iris")
 
 # Disconnect from Athena
 dbDisconnect(con)

--- a/man/sqlCreateTable.Rd
+++ b/man/sqlCreateTable.Rd
@@ -30,7 +30,8 @@ A data frame: field types are generated using
 
 \item{partition}{Partition Athena table (needs to be a named list or vector) for example: \code{c(var1 = "2019-20-13")}}
 
-\item{s3.location}{s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/").}
+\item{s3.location}{s3 bucket to store Athena table, must be set as a s3 uri for example ("s3://mybucket/data/"). 
+By default s3.location is set s3 staging directory from \code{\linkS4class{AthenaConnection}} object.}
 
 \item{file.type}{What file type to store data.frame on s3, noctua currently supports ["csv", "tsv", "parquet"]}
 


### PR DESCRIPTION
Enabled default method for s3.location in `dbWriteTable`. Now data can be sent to Athena with the follow command:
```
library(DBI)

con <- dbConnect(noctua::athena())

dbWriteTable(con, "iris", iris)
```
This should make it easier for users and look more familiar to other databases when using DBI