### PR TITLE
fix issue in #58: writBin is currently restricted to 2^31 - 1 bytes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: noctua
 Type: Package
 Title: Connect to 'AWS Athena' using R 'AWS SDK' 'paws' ('DBI' Interface)
-Version: 1.5.0.9001
+Version: 1.5.0.9002
 Authors@R: person("Dyfan", "Jones", email="dyfan.r.jones@gmail.com", 
                   role= c("aut", "cre"))
 Description: Designed to be compatible with the 'R' package 'DBI' (Database Interface)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# noctua 1.5.0.9002
+#### Bug Fix
+* `writeBin`: Only 2^31 - 1 bytes can be written in a single call (and that is the maximum capacity of a raw vector on 32-bit platforms). This means that it will error out with large raw connections. To over come this `writeBin` can be called in chunks. A faster option would be preferred however current implementation seem effient.
+
 # noctua 1.5.0.9001
 ### New Feature
 * `dbStatistics` is a wrapper around `paws` `get_query_execution` to return statistics for `noctua::dbSendQuery` results

--- a/R/Result.R
+++ b/R/Result.R
@@ -159,7 +159,7 @@ setMethod(
     # download athena output
     tryCatch(obj <- res@connection@ptr$S3$get_object(Bucket = result_info$bucket, Key = result_info$key))
     
-    writeBin(obj$Body, con = File)
+    write_bin(obj$Body, File)
     
     # return metadata of athena data types
     tryCatch(result_class <- res@connection@ptr$Athena$get_query_results(QueryExecutionId = res@info$QueryExecutionId,

--- a/R/utils.R
+++ b/R/utils.R
@@ -179,16 +179,13 @@ data_scanned <-
 write_bin <- function(
   value,
   filename,
-  chunk_size = 2L^20L
-) {
+  chunk_size = 2L ^ 20L) {
+  
   total_size <- length(value)
-  start_byte <- 0L
-  while(start_byte < total_size) {
-    end_byte <- min(start_byte + chunk_size, total_size) - 1L
-    this_chunk <- value[seq(start_byte, end_byte, by = 1)]
-    con <- file(filename, "a+b")
-    writeBin(this_chunk, con)
-    close(con)
-    start_byte <- start_byte + chunk_size
-  }
+  split_vec <- seq(1, total_size, chunk_size)
+  
+  con <- file(filename, "a+b")
+  on.exit(close(con))
+  
+  sapply(split_vec, function(x){writeBin(value[x:min(total_size,(x+chunk_size-1))],con)})
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -174,3 +174,21 @@ data_scanned <-
     if (power == 0) unit <- "Bytes"
     paste(round(x/base^power, digits = 2), unit)
   }
+
+# Write large raw connections in chunks
+write_bin <- function(
+  value,
+  filename,
+  chunk_size = 2L^20L
+) {
+  total_size <- length(value)
+  start_byte <- 0L
+  while(start_byte < total_size) {
+    end_byte <- min(start_byte + chunk_size, total_size) - 1L
+    this_chunk <- value[seq(start_byte, end_byte, by = 1)]
+    con <- file(filename, "a+b")
+    writeBin(this_chunk, con)
+    close(con)
+    start_byte <- start_byte + chunk_size
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -187,5 +187,6 @@ write_bin <- function(
   con <- file(filename, "a+b")
   on.exit(close(con))
   
-  sapply(split_vec, function(x){writeBin(value[x:min(total_size,(x+chunk_size-1))],con)})
+  if (length(split_vec) == 1) writeBin(value,con) else sapply(split_vec, function(x){writeBin(value[x:min(total_size,(x+chunk_size-1))],con)})
+  invisible(TRUE)
 }


### PR DESCRIPTION
`writeBin` has a current issue:
```
Only 2^31 - 1 bytes can be written in a single call (and that is the maximum capacity of a raw vector on 32-bit platforms).
```