### PR TITLE
Do not abort if a get_tables fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ## Bug Fix
 * Pass a uuid string to `start_query_execution` parameter `ClientRequestToken`. This so that the `ClientRequestToken` is "A unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once)." (#104)
 * Allowed cache_size to equal 100
+* Do not abort if a glue::get_tables api call fails (e.g., due to missing permissions to a specific database or an orphaned Lake Formation resource link) when retrieving a list of database tables with dbListTables, dbGetTables or in Rstudio's Connections pane. 
 
 # noctua 1.8.0
 ## New Feature

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -374,7 +374,7 @@ setMethod(
     if (!dbIsValid(conn)) {stop("Connection already closed.", call. = FALSE)}
     if(is.null(schema)){
       retry_api_call(schema <- sapply(conn@ptr$glue$get_databases()$DatabaseList,function(x) x$Name))}
-    tryCatch(output <- lapply(schema, function (x) conn@ptr$glue$get_tables(DatabaseName = x)$TableList))
+    tryCatch(output <- lapply(schema, function (x) tryCatch(conn@ptr$glue$get_tables(DatabaseName = x)$TableList, error = function(cond) NULL)))
     unlist(lapply(output, function(x) sapply(x, function(y) y$Name)))
   }
 )
@@ -419,7 +419,7 @@ setMethod("dbGetTables", "AthenaConnection",
   if (!dbIsValid(conn)) {stop("Connection already closed.", call. = FALSE)}
   if(is.null(schema)){
     retry_api_call(schema <- sapply(conn@ptr$glue$get_databases()$DatabaseList,function(x) x$Name))}
-  tryCatch(output <- lapply(schema, function (x) conn@ptr$glue$get_tables(DatabaseName = x)$TableList))
+  tryCatch(output <- lapply(schema, function (x) tryCatch(conn@ptr$glue$get_tables(DatabaseName = x)$TableList, error = function(cond) NULL)))
   rbindlist(lapply(output, function(x) rbindlist(lapply(x, function(y) data.frame(Schema = y$DatabaseName,
                                                                                   TableName=y$Name,
                                                                                   TableType = y$TableType)))))

--- a/R/View.R
+++ b/R/View.R
@@ -167,7 +167,7 @@ AthenaTableTypes <- function(connection, database = NULL, name = NULL, ...) {
   
   if(is.null(database)) database <- sapply(glue$get_databases()$DatabaseList,function(x) x$Name)
   if(is.null(name)){
-    output <- lapply(database, function (x) glue$get_tables(DatabaseName = x)$TableList)
+    output <- lapply(database, function (x) tryCatch(glue$get_tables(DatabaseName = x)$TableList, error = function(cond) NULL))
     tbl_meta <- unlist(lapply(output, function(x) sapply(x, TblMeta)))}
   else{
     output <- glue$get_table(DatabaseName = database, Name = name)$Table
@@ -390,4 +390,4 @@ TblMeta <- function(x) {
 ColMeta <- function(x){
   col_type <- x$Type %||% ""
   names(col_type) <- x$Name
-  col_type} 
+  col_type}


### PR DESCRIPTION
An issue connected to the Lake Formation service in AWS appeared:

Lake Formation can be used to share content from one AWS account's glue catalog to another account.

The problem arises, when:
1. A Lake formation share is created on account A
2. A resource link is created on account B
3. The share on acc A is removed leaving an 'oprhaned' resource link

Now, when a user tries to establish a noctua/Athena connection, an error occurs, as the user on account B doesn't have permission to get_tables on account B:s data catalog anymore.

This pull request makes the get_tables error tolerant so that if access is denied, an empty list of tables is put forward.

Probably the multiple tryCatche's are unnecessary now, but I hope this at least outlines the idea how one could address the issue.

Br, Ossi