### PR TITLE
dbRemoveTable performance enhancement

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -299,3 +299,12 @@ ctas_sql_with <- function(partition = NULL, s3.location = NULL, file.type = "NUL
     paste0("WITH (", FILE, COMPRESSION, LOCATION, PARTITION,")\n")
   } else ""
 }
+
+# split list into chunksize 1000
+splitList <- function(l){
+  chunks <- seq(1, length(l), 1000)
+  ll <- Map(function(i) list(), 1:length(chunks))
+  for (i in seq_along(chunks))
+    ll[[i]] <- l[chunks[i]:min(chunks[i]+999, length(l))]
+  return(ll)
+}


### PR DESCRIPTION
`dbRemoveTable` now calls `paws::s3()$delete_objects` instead of `paws::s3()$delete_object`

```r
library(DBI)
library(data.table)

X <- 1010
value <- data.table(x = 1:X,
                    y = sample(letters, X, replace = T), 
                    z = sample(c(TRUE, FALSE), X, replace = T))

con <- dbConnect(noctua::athena())

# create a removable table with 1010 parquet files in AWS S3.
dbWriteTable(con, "rm_tbl", value, file.type = "parquet", overwrite = T, max.batch = 1)

# old method: delete_object
system.time({dbRemoveTable(con, "rm_tbl", confirm = T)})
# user  system elapsed 
# 31.004   8.152 115.906 

# new method: delete_objects
system.time({dbRemoveTable(con, "rm_tbl", confirm = T)})
# user  system elapsed 
# 17.319   0.370  22.709 
```