### PR TITLE
connection performance

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -483,8 +483,6 @@ setMethod(
   "dbListTables", "AthenaConnection",
   function(conn, catalog = NULL, schema = NULL, ...) {
     con_error_msg(conn, msg = "Connection already closed.")
-    athena <- conn@ptr$Athena
-
     cat_filter <- ""
     db_filter <- ""
     if (!is.null(catalog)) {

--- a/R/fetch_utils.R
+++ b/R/fetch_utils.R
@@ -25,10 +25,7 @@
     ))
 
     # process returned list
-    output <- lapply(
-      result[["ResultSet"]][["Rows"]],
-      function(x) (sapply(x$Data, function(x) if (length(x) == 0) NA else x))
-    )
+    output <- do.call(rbind, result[["ResultSet"]][["Rows"]])
     suppressWarnings(staging_dt <- rbindlist(output, use.names = FALSE))
 
     # remove colnames from first row
@@ -59,8 +56,8 @@
   res@info[["NextToken"]] <- result[["NextToken"]]
 
   # replace names with actual names
-  Names <- sapply(result_class, function(x) x[["Name"]])
-  colnames(dt) <- Names
+  Names <- do.call(rbind, result_class)[,"Name"]
+  colnames(dt) <- as.character(Names)
 
   # convert data.table to tibble if using vroom as backend
   if (inherits(athena_option_env[["file_parser"]], "athena_vroom")) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -378,11 +378,11 @@ list_catalogs <- function(client) {
   i <- 1
   while (!identical(token, character(0))) {
     response <- client$list_data_catalogs(NextToken = token)
-    data_list[[i]] <- vapply(response[["DataCatalogsSummary"]], function(x) x[["CatalogName"]], FUN.VALUE = character(1))
+    data_list[[i]] <- response[["DataCatalogsSummary"]]
     token <- response[["NextToken"]]
     i <- i + 1
   }
-  return(unlist(data_list, recursive = FALSE, use.names = FALSE))
+  return(as.character(do.call(rbind, unlist(data_list, recursive = F))[, "CatalogName"]))
 }
 
 # list database
@@ -392,37 +392,11 @@ list_schemas <- function(client, catalog) {
   i <- 1
   while (!identical(token, character(0))) {
     response <- client$list_databases(CatalogName = catalog, NextToken = token)
-    data_list[[i]] <- vapply(response[["DatabaseList"]], function(x) x[["Name"]], FUN.VALUE = character(1))
+    data_list[[i]] <- response[["DatabaseList"]]
     token <- response[["NextToken"]]
     i <- i + 1
   }
-  return(unlist(data_list, recursive = FALSE, use.names = FALSE))
-}
-
-# get list of tables from glue catalog
-list_tables <- function(client, catalog, schema) {
-  token <- NULL
-  table_list <- list()
-  i <- 1
-  while (!identical(token, character(0))) {
-    retry_api_call(response <- client$list_table_metadata(
-      CatalogName = catalog, DatabaseName = schema, NextToken = token
-    ))
-    table_list[[i]] <- lapply(
-      response[["TableMetadataList"]],
-      function(x) {
-        list(
-          CatalogName = catalog,
-          DatabaseName = schema,
-          Name = x[["Name"]],
-          TableType = x[["TableType"]]
-        )
-      }
-    )
-    token <- response[["NextToken"]]
-    i <- i + 1
-  }
-  return(unlist(table_list, recursive = FALSE, use.names = FALSE))
+  return(as.character(do.call(rbind, unlist(data_list, recursive = F))[, "Name"]))
 }
 
 # wrapper to return connection error when disconnected

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -20,7 +20,7 @@ test_that("Check if Athena list object types is formatted correctly",{
           schema = list(
             contains = list(
               table = list(contains = "data"),
-              view = list(contains = "data")
+              # view = list(contains = "data") # information_schema.tables returns all TableType as "BASE TABLE"
             )
           )
         )

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -19,7 +19,7 @@ test_that("Check if Athena list object types is formatted correctly",{
         contains = list(
           schema = list(
             contains = list(
-              table = list(contains = "data"),
+              table = list(contains = "data")
               # view = list(contains = "data") # information_schema.tables returns all TableType as "BASE TABLE"
             )
           )


### PR DESCRIPTION
This PR attempts to address the performance of Rstudio connection tab. Currently noctua makes sdk calls to athena to get the table list, catalog and schema. This proves to be fast for small scale data schemas however it is super slow for large data schema. This is down to the restriction of 50 objects per call.

Issue: [#197](https://github.com/DyfanJones/noctua/issues/194)