### PR TITLE
Fix buckets with no key prefix in `unload = TRUE` related functions

### DIFF
--- a/R/fetch_utils.R
+++ b/R/fetch_utils.R
@@ -70,7 +70,7 @@
 
 .fetch_unload <- function(res) {
   result_info <- split_s3_uri(res@connection@info[["s3_staging"]])
-  result_info[["key"]] <- file.path(gsub("/$", "", result_info[["key"]]), res@info[["UnloadDir"]])
+  result_info[["key"]] <- gsub("^/", "", file.path(gsub("/$", "", result_info[["key"]]), res@info[["UnloadDir"]]))
 
   all_keys <- list()
   token <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@ split_s3_uri <- function(uri) {
   path <- gsub("^s3://", "", uri)
   list(
     bucket = gsub("/.*$", "", path),
-    key = gsub("^[a-z0-9][a-z0-9\\.-]+[a-z0-9]/", "", path)
+    key = gsub("^[a-z0-9][a-z0-9\\.-]+[a-z0-9](/|$)", "", path)
   )
 }
 


### PR DESCRIPTION
This PR makes two minor changes to fix the issues described in #214. Mainly, it allows passing a bucket path with no key prefix when using the `unload = TRUE` option in `dbGetQuery()` and similar functions.

To illustrate, the setup below currently returns correct results:

```r
con <- DBI::dbConnect(noctua::athena(), s3_staging_dir = "s3://temp-bucket/test/")
dbGetQuery(conn = con, "SELECT * FROM test_db", unload = TRUE)
```

But the following two setups do not:

```r
con <- DBI::dbConnect(noctua::athena(), s3_staging_dir = "s3://temp-bucket/")
dbGetQuery(conn = con, "SELECT * FROM test_db", unload = TRUE)
```

```r
con <- DBI::dbConnect(noctua::athena(), s3_staging_dir = "s3://temp-bucket")
dbGetQuery(conn = con, "SELECT * FROM test_db", unload = TRUE)
```

Closes #214.