### PR TITLE
Fixing `data.table::fread` parsing when result file contains one column

### DIFF
--- a/R/File_Parser.R
+++ b/R/File_Parser.R
@@ -16,7 +16,9 @@ athena_read.athena_data.table <- function(method, File, athena_types, con, ...){
   Type2 <- Type <- AthenaToRDataType(method, data_type)
   # Type2 is to handle issue with data.table fread 
   Type2[Type2 %in% "POSIXct"] <- "character"
-  
+
+  sep <- if (length(Type) == 1L) "\n" else ","
+
   fill <- any(c("array", "row", "map", "json") %in% data_type)
   
   # currently parameter data.table is left as default. If users require data.frame to be returned then parameter will be updated
@@ -26,7 +28,7 @@ athena_read.athena_data.table <- function(method, File, athena_types, con, ...){
       File,
       col.names = names(Type2),
       colClasses = unname(Type2),
-      sep = ",",
+      sep = sep,
       showProgress = F,
       na.strings="",
       fill = fill)
@@ -38,7 +40,7 @@ athena_read.athena_data.table <- function(method, File, athena_types, con, ...){
       col.names = names(Type),
       colClasses = unname(Type),
       tz = con@info$timezone,
-      sep = ",",
+      sep = sep,
       showProgress = F,
       na.strings="",
       fill = fill)


### PR DESCRIPTION
Hi @DyfanJones,

Thanks again for this package.

I have found that when a query is expected to return a single result column, the `data.table::fread()` call inside the `athena_read.athena_data.table()` method can fail under certain circumstances. The output must be a single column and the data must contain at least one `,` character. For example, if the temporary file downloaded with `.fetch_file()` contains the following data:

```
"column_name"
"first value"
"second, value"
"third value"
```

You will get an error to the effect of:

```
Error in setnames(ans, col.names) :
  Can't assign 1 names to a 2-column data.table
In addition: Warning messages:
1: In data.table::fread(File, col.names = names(Type), colClasses = unname(Type),  :
  Found and resolved improper quoting in first 100 rows. If the fields are not quoted (e.g. field separator does not appear within any field), try quote="" to avoid this warning.
2: In data.table::fread(File, col.names = names(Type), colClasses = unname(Type),  :
  Detected 1 column names but the data has 2 columns (i.e. invalid file). Added 1 extra default column name for the first column which is guessed to be row names or an index. Use setnames() afterwards if this guess is not correct, or fix the file write command that created the file to create a valid file.
3: In data.table::fread(File, col.names = names(Type), colClasses = unname(Type),  :
  Stopped early on line 4. Expected 2 fields but found 1. Consider fill=TRUE and comment.char=. First discarded non-empty line: <<"third value">>
```

My understanding is that this is happening because `fread()` incorrectly strips the double quotes surrounding the rows. Then in the `"second, value"` row, it sees an unquoted separator character `,` and wrongly deduces that this is a two-column dataset. When it gets to the `"third value"` row, it can't find a separator character in the data and panics.

By checking the number of columns expected and using `\n` as the separator when there is only one column, `fread()` behaves as we would hope.

I am adding this onto the PR for `noctua_2.6.3` because I have been working in that branch since it solves a different issue I was having with `dplyr::compute()`. I'm happy to switch the base to your `main` branch.

Thanks,

Paul
