### PR TITLE
Update for dbplyr 2nd edition

### DIFF
--- a/R/dplyr_integration.R
+++ b/R/dplyr_integration.R
@@ -101,8 +101,8 @@ db_compute.AthenaConnection <- function(
       call. = FALSE
     )
   }
-  db_save_query <- pkg_method("db_save_query", "dplyr")
-  table <- db_save_query(
+  sql_query_save <- pkg_method("sql_query_save", "dbplyr")
+  table <- sql_query_save(
     con,
     sql,
     table,
@@ -399,14 +399,14 @@ sql_query_fields.AthenaConnection <- function(con, sql, ...) {
     return(sql)
   } else {
     # None ident class uses dbplyr:::sql_query_fields.DBIConnection method
-    dbplyr_query_select <- pkg_method("dbplyr_query_select", "dbplyr")
-    sql_subquery <- pkg_method("sql_subquery", "dplyr")
+    sql_query_select <- pkg_method("sql_query_select", "dbplyr")
+    sql_query_wrap <- pkg_method("sql_query_wrap", "dbplyr")
     dplyr_sql <- pkg_method("sql", "dplyr")
 
-    return(dbplyr_query_select(
+    return(sql_query_select(
       con,
       dplyr_sql("*"),
-      sql_subquery(con, sql),
+      sql_query_wrap(con, sql),
       where = dplyr_sql("0 = 1")
     ))
   }
@@ -494,14 +494,14 @@ athena_query_fields_ident <- function(con, sql) {
   } else {
     # If a subquery, query Athena for the fields
     # return dplyr methods
-    sql_select <- pkg_method("sql_select", "dplyr")
-    sql_subquery <- pkg_method("sql_subquery", "dplyr")
+    sql_query_select <- pkg_method("sql_query_select", "dbplyr")
+    sql_query_wrap <- pkg_method("sql_query_wrap", "dbplyr")
     dplyr_sql <- pkg_method("sql", "dplyr")
 
-    sql <- sql_select(
+    sql <- sql_query_select(
       con,
       dplyr_sql("*"),
-      sql_subquery(con, sql),
+      sql_query_wrap(con, sql),
       where = dplyr_sql("0 = 1")
     )
     qry <- dbSendQuery(con, sql)
@@ -520,14 +520,14 @@ db_query_fields.AthenaConnection <- function(con, sql, ...) {
   } else {
     # If a subquery, query Athena for the fields
     # return dplyr methods
-    sql_select <- pkg_method("sql_select", "dplyr")
-    sql_subquery <- pkg_method("sql_subquery", "dplyr")
+    sql_query_select <- pkg_method("sql_query_select", "dbplyr")
+    sql_query_wrap <- pkg_method("sql_query_wrap", "dbplyr")
     dplyr_sql <- pkg_method("sql", "dplyr")
 
-    sql <- sql_select(
+    sql <- sql_query_select(
       con,
       dplyr_sql("*"),
-      sql_subquery(con, sql),
+      sql_query_wrap(con, sql),
       where = dplyr_sql("0 = 1")
     )
     qry <- dbSendQuery(con, sql)


### PR DESCRIPTION
Hi,

This is a fantastic package, thanks for creating it!

This PR fixed the integration with `dbplyr` which stopped working with v2.6.0 (as in #231). All it does is replace the references in dplyr_integration.R for the `dplyr` generics with the newer `dbplyr` equivalents, as explained here: https://dbplyr.tidyverse.org/articles/backend-2.html#renamed-generics

This works in my limited use cases, but I haven't tested it against all the things noctua can do, so very happy to be told that I've missed something. But hope this can be helpful to getting noctua to play nicely with dbplyr again.